### PR TITLE
Fixing crash on clearing empty cache

### DIFF
--- a/espresso-macchiato/src/androidTest/java/de/nenick/espressomacchiato/tools/EspAppDataToolTest.java
+++ b/espresso-macchiato/src/androidTest/java/de/nenick/espressomacchiato/tools/EspAppDataToolTest.java
@@ -136,6 +136,14 @@ public class EspAppDataToolTest extends EspressoTestCase<BaseActivity> {
     }
 
     @Test
+    public void testClearCacheFilesWhenNoCacheExists() throws IOException {
+        File cacheDir = InstrumentationRegistry.getTargetContext().getCacheDir();
+        deleteChildFile(cacheDir, cacheDir);
+
+        EspAppDataTool.clearCache();
+    }
+
+    @Test
     public void testClearCacheFiles() throws IOException {
         Uri uri = givenCacheFile(FILE_NAME);
 
@@ -240,5 +248,19 @@ public class EspAppDataToolTest extends EspressoTestCase<BaseActivity> {
 
     private void thenCustomPreferencesIsCleared(SharedPreferences customPreferences) {
         assertThat(customPreferences.getString(CUSTOM_PREFERENCE, PRFERENCE_FALLBACK_VALUE), is(PRFERENCE_FALLBACK_VALUE));
+    }
+
+    private void deleteChildFile(File parentDir, File targetFile) {
+        if(targetFile.isDirectory()) {
+            File[] files = targetFile.listFiles();
+            if(files != null) {
+                for (File file : files) {
+                    deleteChildFile(parentDir, file);
+                }
+            }
+        }
+        if(!targetFile.equals(parentDir) && !targetFile.delete()) {
+            throw new IllegalStateException("Failed to delete file: " + targetFile);
+        }
     }
 }

--- a/espresso-macchiato/src/main/java/de/nenick/espressomacchiato/tools/EspAppDataTool.java
+++ b/espresso-macchiato/src/main/java/de/nenick/espressomacchiato/tools/EspAppDataTool.java
@@ -105,7 +105,9 @@ public class EspAppDataTool {
      */
     public static void clearCache() {
         File cacheDir = InstrumentationRegistry.getTargetContext().getCacheDir();
-        assertThat(deleteRecursive(cacheDir), is(true));
+        if(cacheDir.list() != null) {
+            assertThat(deleteRecursive(cacheDir), is(true));
+        }
     }
 
     /**


### PR DESCRIPTION
Problem I am trying to solve is that AppDataTools are crashing when app cache is empty AND `clearCache()` is called.

According to SDK method `cacheDir.list()` documentation it should return empty array when dir exists. But in this particular scenario it returns `null`.